### PR TITLE
Add transport options to MCP server and update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
+    "typer>=0.9.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -802,6 +802,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -843,6 +844,7 @@ requires-dist = [
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.22.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "typer", specifier = ">=0.9.0" },
 ]
 provides-extras = ["dev", "test-client"]
 


### PR DESCRIPTION
- Introduced a new Transport enum for available transport methods (stdio, sse, http).
- Modified the main function to accept transport, host, and port as options using Typer.
- Updated pyproject.toml to include Typer as a dependency.

Generated-by: claude-4-sonnet