### PR TITLE
[DO NOT MERGE] submit_request brew builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Submit a FMF test request to Testing Farm.
 - `test_name` (optional): Select tests to be executed. Can be a regular expression
 - `context` (optional): TMT context variables as key-value pairs
 - `environment` (optional): TMT environment variables as key-value pairs
+- `brew_builds` (optional): List of Brew builds to test against. Each item can be a task ID (int) or NVR string (e.g., ['httpd-2.4.54-1.el9', 12345])
 
 **Example:**
 ```json
@@ -89,7 +90,8 @@ Submit a FMF test request to Testing Farm.
   "arch": "x86_64",
   "environment": {
     "TEST_VAR": "test_value"
-  }
+  },
+  "brew_builds": ["httpd-2.4.54-1.el9"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,34 +70,26 @@ just start
 Submit a FMF test request to Testing Farm.
 
 **Parameters:**
-- `url` (required): Git repository URL containing FMF metadata
-- `ref` (optional): Branch, tag, or commit to test
-- `merge_sha` (optional): Target commit SHA for merge testing
-- `path` (optional): Path to metadata tree root
-- `plan_name` (optional): Specific test plan to execute
-- `plan_filter` (optional): Filter for tmt plans
-- `test_name` (optional): Specific test to execute
-- `test_filter` (optional): Filter for tmt tests
-- `environments` (optional): Test environment configurations
-- `notification` (optional): Notification settings
-- `settings` (optional): Additional request settings
-- `user` (optional): User information
+- `url` (required): Git repository URL containing the TMT metadata
+- `compose` (required): Compose to run tests against
+- `ref` (optional): Git branch, tag or commit specifying the desired git revision
+- `metadata_root_dir` (optional): Path to the metadata tree root directory. By default git repository root
+- `arch` (optional): Architecture to test against, by default 'x86_64'
+- `plan_name` (optional): Selected plans to be executed. Can be a regular expression
+- `test_name` (optional): Select tests to be executed. Can be a regular expression
+- `context` (optional): TMT context variables as key-value pairs
+- `environment` (optional): TMT environment variables as key-value pairs
 
 **Example:**
 ```json
 {
   "url": "https://github.com/example/test-repo",
+  "compose": "fedora-39",
   "ref": "main",
-  "path": "/tests",
-  "environments": [
-    {
-      "arch": "x86_64",
-      "os": "fedora-38",
-      "variables": {
-        "TEST_VAR": "test_value"
-      }
-    }
-  ]
+  "arch": "x86_64",
+  "environment": {
+    "TEST_VAR": "test_value"
+  }
 }
 ```
 

--- a/testing_farm_mcp/server.py
+++ b/testing_farm_mcp/server.py
@@ -87,6 +87,15 @@ async def submit_request(  # noqa: PLR0913
             description="TMT environment variables as key-value pairs (e.g., {'ROOTLESS_USER': 'ec2-user'}).",
         ),
     ] = None,
+    brew_builds: Annotated[
+        list[int | str] | None,
+        Field(
+            description=(
+                "List of Brew builds to test against. Each item can be a task ID (int) or NVR string"
+                " (e.g., ['httpd-2.4.54-1.el9', 12345])."
+            ),
+        ),
+    ] = None,
 ) -> dict[str, Any]:
     """Submit a test request to Testing Farm.
 
@@ -103,6 +112,7 @@ async def submit_request(  # noqa: PLR0913
         arch: Architecture to test against
         context: TMT context variables as key-value pairs
         environment: TMT environment variables as key-value pairs
+        brew_builds: List of Brew builds to test against (task IDs or NVRs)
 
     Returns:
         Testing Farm request creation response
@@ -110,12 +120,31 @@ async def submit_request(  # noqa: PLR0913
     client = TestingFarmClient()
     try:
         # Build environment configuration
-        env_config = {
+        env_config: dict[str, Any] = {
             "arch": arch,
             "os": {
                 "compose": compose,
             },
         }
+
+        # Build artifacts list
+        artifacts = []
+
+        # Add Brew build artifacts if specified
+        if brew_builds:
+            for brew_build in brew_builds:
+                # Convert int task IDs to strings
+                build_id = str(brew_build)
+
+                brew_artifact = {
+                    "type": "redhat-brew-build",
+                    "id": build_id,
+                }
+                artifacts.append(brew_artifact)
+
+        # Add artifacts to environment configuration if any are specified
+        if artifacts:
+            env_config["artifacts"] = artifacts
 
         # Add TMT configuration if context or environment variables are provided
         if context or environment:


### PR DESCRIPTION
This PR adds a brew_builds parameter to the submit_request tool. I'm not too happy with it - I feel that more of the flexibility of the artifacts parameter  in the API is needed - but I don't know exactly *what* part of that flexibility will be needed.

Is it better to to just have a artifacts parameter that literally matches the API and takes a list of:

``` python
class Artifact(TypedDict):
   id: str
   type: ArtifactType
   packages: NotRequired[list[str]]
   install: NotRequired[boolean]
   order: NotRequired[int]
```

?